### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Python library wrapping [the iFixit API].
 
 # Status
 
-[![Version](https://pypip.in/v/pyfixit/badge.png)](https://crate.io/packages/pyfixit)
+[![Version](https://img.shields.io/pypi/v/pyfixit.svg)](https://crate.io/packages/pyfixit)
 
 Working, but incomplete.  Fully tested and documented.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyfixit))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyfixit`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.